### PR TITLE
Update use-field-like.ts

### DIFF
--- a/lib/field-array-item/field-array-item.tsx
+++ b/lib/field-array-item/field-array-item.tsx
@@ -98,7 +98,6 @@ export function FieldArrayItemComp<T = any, F = any>(
       array.setValue(itemIndex, newArrayObject as T);
 
       setIsDirty(true);
-      setIsTouched(true);
 
       /**
        * Call `listenTo` field subscribers for other fields.

--- a/lib/field/field.spec.tsx
+++ b/lib/field/field.spec.tsx
@@ -871,3 +871,39 @@ test("Field should not throw error if manually validate against non-used validat
   await user.click(getByText("Validate"));
   expect(queryByText("Must be at least three")).not.toBeInTheDocument();
 });
+
+test("isTouched should only change onBlur", async () => {
+  let touchedValue;
+  const { getByPlaceholderText } = render(
+    <Form onSubmit={(_) => {}}>
+      {() => (
+        <Field<string> name="email" initialValue="">
+          {({ value, setValue, onBlur, isTouched }) => {
+            touchedValue = isTouched;
+            return (
+              <input
+                placeholder="Email"
+                onBlur={onBlur}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
+            );
+          }}
+        </Field>
+      )}
+    </Form>
+  );
+
+  const emailInput = getByPlaceholderText("Email");
+
+  // Initially, isTouched should be false
+  expect(touchedValue).toBeFalsy();
+
+  // After changing the input value, isTouched should still be false
+  await fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+  expect(touchedValue).toBeFalsy();
+
+  // After triggering the onBlur event, isTouched should be true
+  await fireEvent.blur(emailInput);
+  expect(touchedValue).toBeTruthy();
+});

--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -191,7 +191,7 @@ export const useFieldLike = <
           typeof t === "function";
         const newVal = isPrevAFunction(val) ? val(prev) : (val as typeof value);
         setIsDirty(true);
-        setIsTouched(true);
+        // setIsTouched(true);
 
         /**
          * Call `listenTo` field subscribers for other fields.

--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -191,7 +191,6 @@ export const useFieldLike = <
           typeof t === "function";
         const newVal = isPrevAFunction(val) ? val(prev) : (val as typeof value);
         setIsDirty(true);
-        // setIsTouched(true);
 
         /**
          * Call `listenTo` field subscribers for other fields.


### PR DESCRIPTION
Hello, thanks for the awesome library!

I believe the behaviour of `isTouched` is not working as it should be.
Right now, if I click on a field and type something, the field becomes "touched" and "dirty".
I think it should only be "touched" once the user clicks away. I have commented out the `setIsTouched(true)` that happens when the field's value is updated. This means that `isTouched` will only be updated `onBlur`.
This helps to **display errors only when the user leaves the field**.

I think this is the standard. Here is a quick reference:
"touched only update onBlur, I believe this is pretty much a standard now which means users have interacted with the input" -> https://github.com/react-hook-form/react-hook-form/discussions/8474

Any feedback is appreciated. Thanks a lot!