### PR TITLE
fix intro video overflow on mobile

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -24,8 +24,8 @@ Good question, let's break that down:
 
 - **Field first**: Other React form libraries focus on the form itself - forcing you to use a schema object to define all of your fields. This introduces two problems:
 
-  1) Your field validation logic and your field UI rendering are separated. You have to look in more than one place to see the whole picture of your field logic - the field itself and the validation schema defined at the form level.
-  2) Defining per-field validation (say, one field validates by submit logic while the other validates `onBlur`, while another validates `onChange`) is challenging or downright impossible.
+  1. Your field validation logic and your field UI rendering are separated. You have to look in more than one place to see the whole picture of your field logic - the field itself and the validation schema defined at the form level.
+  2. Defining per-field validation (say, one field validates by submit logic while the other validates `onBlur`, while another validates `onChange`) is challenging or downright impossible.
 
   By focusing on fields, the items that make up the form, it alleviates many of these concerns.
 
@@ -41,7 +41,7 @@ Good question, let's break that down:
 [James Perkins](https://www.youtube.com/@james-perkins) recently made an incredible video intro to HouseForm over on his YouTube channel:
 
 <div align="center">
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/bQVUGx8rSuQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" style="aspect-ratio: 16/9; max-width: 100%;" src="https://www.youtube-nocookie.com/embed/bQVUGx8rSuQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
 ## Installation
@@ -68,10 +68,12 @@ export default function App() {
       }}
     >
       {({ isValid, submit }) => (
-        <form onSubmit={e => {
-          e.preventDefault();
-          submit();
-        }}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+        >
           <Field
             name="email"
             onBlurValidate={z.string().email("This must be an email")}
@@ -137,9 +139,8 @@ export default function App() {
                     placeholder={"Password Confirmation"}
                     type="password"
                   />
-                  {isTouched && errors.map((error) => (
-                    <p key={error}>{error}</p>
-                  ))}
+                  {isTouched &&
+                    errors.map((error) => <p key={error}>{error}</p>)}
                 </div>
               );
             }}


### PR DESCRIPTION
I noticed the video introduction `iframe` in the introduction page is overflowing on mobile due to it fixed width and height attributes.
I removed added a max width of 100% so that it doesn't overflow. But now the video proportions are messed up. So, I removed the fixed height and added aspect ratio of 16:9.