### PR TITLE
feat: allow for empty strings in resetwithvalue

### DIFF
--- a/lib/form/form.spec.tsx
+++ b/lib/form/form.spec.tsx
@@ -1390,6 +1390,83 @@ test("Form should reset with resetWithValues correctly", async () => {
       `)
   );
 });
+test("Form should reset with empty string resetWithValue correctly", async () => {
+  const ResetValues = () => {
+    return (
+      <Form
+        onSubmit={(_values, { reset }) => {
+          reset();
+        }}
+      >
+        {({ submit, isDirty, isTouched }) => (
+          <>
+            <Field<string>
+              name={"test['other']['email']"}
+              initialValue="initial@email.com"
+              resetWithValue=""
+            >
+              {({ value, setValue }) => (
+                <input
+                  placeholder="Email"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                />
+              )}
+            </Field>
+            <Field<string>
+              name={"test['other']['password']"}
+              resetWithValue="password"
+            >
+              {({ value, setValue }) => (
+                <input
+                  placeholder="Password"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                />
+              )}
+            </Field>
+            <button onClick={submit}>Submit</button>
+            <p>{isDirty ? "isDirty" : "isNotDirty"}</p>
+            <p>{isTouched ? "isTouched" : "isNotTouched"}</p>
+          </>
+        )}
+      </Form>
+    );
+  };
+
+  const { getByText, container, getByPlaceholderText } = render(
+    <ResetValues />
+  );
+
+  await user.type(getByPlaceholderText("Email"), "test");
+  await user.type(getByPlaceholderText("Password"), "test");
+
+  await user.click(getByText("Submit"));
+
+  await waitFor(() =>
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <input
+          placeholder="Email"
+          value=""
+        />
+        <input
+          placeholder="Password"
+          value="password"
+        />
+        <button>
+          Submit
+        </button>
+        <p>
+          isNotDirty
+        </p>
+        <p>
+          isNotTouched
+        </p>
+      </div>
+      `)
+  );
+});
 
 test("Form should reset with resetWithValues and initial values correctly", async () => {
   const ResetValues = () => {

--- a/lib/form/form.tsx
+++ b/lib/form/form.tsx
@@ -243,7 +243,7 @@ function FormComp<T extends Record<string, any> = Record<string, any>>(
         );
       })
       .forEach((field) => {
-        const value = field.props.resetWithValue || field.props.initialValue;
+        const value = field.props.resetWithValue ?? field.props.initialValue;
 
         const isFieldArray = (v: typeof field): v is FieldArrayInstance => {
           return !!(v as FieldArrayInstance).setValues;


### PR DESCRIPTION
# Pull Request Template

## Proposed Changes

Allows you to have an empty string for a resetWithValue prop that still gets applied.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
