### PR TITLE
Fix reset usage with FieldArrayItem

### DIFF
--- a/lib/field-array-item/field-array-item.spec.tsx
+++ b/lib/field-array-item/field-array-item.spec.tsx
@@ -26,7 +26,7 @@ test("Field array item should submit with values in tact", async () => {
                 <>
                   {value.map((person, i) => (
                     <FieldArrayItem<number>
-                      key={person.thing}
+                      key={`people[${i}].thing`}
                       name={`people[${i}].thing`}
                     >
                       {({ value, setValue }) => (
@@ -80,7 +80,7 @@ test("Field array item be able to set a value", async () => {
             <>
               {value.map((person, i) => (
                 <FieldArrayItem<number>
-                  key={person.thing}
+                  key={`people[${i}].thing`}
                   name={`people[${i}].thing`}
                 >
                   {({ value, setValue }) => (
@@ -571,4 +571,48 @@ test("field array item should set isValidating with onSubmit validation", async 
   expect(getByText("Validating")).toBeInTheDocument();
 
   await waitForElementToBeRemoved(() => queryByText("Validating"));
+});
+
+test("Field array item should not be dirty when form reset", async () => {
+  const { getByText } = render(
+    <Form>
+      {({ reset }) => (
+        <>
+          <FieldArray<{ thing: number }>
+            initialValue={[{ thing: 1 }]}
+            name={"people"}
+          >
+            {({ value }) => (
+              <>
+                {value.map((person, i) => (
+                  <FieldArrayItem<number>
+                    key={`people[${i}].thing`}
+                    name={`people[${i}].thing`}
+                  >
+                    {({ setValue, isDirty }) => (
+                      <div>
+                        <button onClick={() => setValue(2)}>Set value</button>
+                        <p>{isDirty ? "Dirty" : "Clean"}</p>
+                      </div>
+                    )}
+                  </FieldArrayItem>
+                ))}
+              </>
+            )}
+          </FieldArray>
+          <button onClick={() => reset()}>Reset</button>
+        </>
+      )}
+    </Form>
+  );
+
+  expect(getByText("Clean")).toBeInTheDocument();
+
+  await user.click(getByText("Set value"));
+
+  expect(getByText("Dirty")).toBeInTheDocument();
+
+  await user.click(getByText("Reset"));
+
+  expect(getByText("Clean")).toBeInTheDocument();
 });

--- a/lib/field-array-item/field-array-item.tsx
+++ b/lib/field-array-item/field-array-item.tsx
@@ -11,6 +11,7 @@ import { useFieldArrayContext } from "../field-array/context";
 import {
   FieldInstance,
   FieldInstanceProps,
+  InternalValue,
   isInternal,
   useFieldLike,
   useFieldLikeSync,
@@ -101,11 +102,16 @@ export function FieldArrayItemComp<T = any, F = any>(
 
       const newArrayObject = { ...array.value[itemIndex] } as object;
       fillPath(newArrayObject, accessorPath.join("."), newVal);
-      array.setValue(itemIndex, newArrayObject as T);
-
       if (isResetting) {
+        array.setValue(itemIndex, {
+          __value: newArrayObject,
+          __isResetting: true,
+        } as InternalValue<T> as T);
+
         return;
       }
+
+      array.setValue(itemIndex, newArrayObject as T);
 
       setIsDirty(true);
 

--- a/lib/field-array/field-array.spec.tsx
+++ b/lib/field-array/field-array.spec.tsx
@@ -432,6 +432,36 @@ test("field array should set isValidating with onSubmit validation", async () =>
   await waitForElementToBeRemoved(() => queryByText("Validating"));
 });
 
+test("FieldArray should not be dirty if form is reset", async () => {
+  const { getByText } = render(
+    <Form onSubmit={(values) => {}}>
+      {({ reset }) => (
+        <>
+          <FieldArray<number> name={"people"} initialValue={[1]}>
+            {({ add, isDirty }) => (
+              <>
+                <button onClick={() => add(2)}>Add two</button>
+                <p>{isDirty ? "Dirty" : "Clean"}</p>
+              </>
+            )}
+          </FieldArray>
+          <button onClick={() => reset()}>Reset</button>
+        </>
+      )}
+    </Form>
+  );
+
+  expect(getByText("Clean")).toBeInTheDocument();
+
+  await user.click(getByText("Add two"));
+
+  expect(getByText("Dirty")).toBeInTheDocument();
+
+  await user.click(getByText("Reset"));
+
+  expect(getByText("Clean")).toBeInTheDocument();
+});
+
 test.todo("Should work with listenTo");
 
 test.todo("Should expose meta fields to ref");

--- a/lib/field-array/field-array.spec.tsx
+++ b/lib/field-array/field-array.spec.tsx
@@ -4,8 +4,9 @@ import {
   render,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
-import { Field, FieldArray, Form } from "houseform";
+import { Field, FieldArray, FieldArrayItem, Form } from "houseform";
 import { z } from "zod";
+import * as React from "react";
 
 test("field array should track `isDirty` for the array of values", async () => {
   const { getByText, queryByText } = render(
@@ -456,6 +457,66 @@ test("FieldArray should not be dirty if form is reset", async () => {
   await user.click(getByText("Add two"));
 
   expect(getByText("Dirty")).toBeInTheDocument();
+
+  await user.click(getByText("Reset"));
+
+  expect(getByText("Clean")).toBeInTheDocument();
+});
+
+test("FieldArray should not be dirty if form is reset when sub-children are present", async () => {
+  const Comp = () => {
+    const products = [
+      { name: "T-Shirt", price: 19.99 },
+      { name: "Hoodie", price: 39.99 },
+      { name: "Jeans", price: 29.99 },
+    ];
+
+    return (
+      <Form
+        onSubmit={(values, form) => {
+          alert("Form was submitted with: " + JSON.stringify(values));
+        }}
+      >
+        {({ submit, reset, isDirty }) => (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              submit();
+            }}
+          >
+            <div>{isDirty ? "Dirty" : "Clean"}</div>
+            <FieldArray<{ name: string; price: number }>
+              name="products"
+              initialValue={products}
+            >
+              {({ value, errors }) => (
+                <div>
+                  {value.map((val, i) => (
+                    <div key={i}>
+                      <FieldArrayItem<number>
+                        key={i}
+                        name={`products[${i}].price`}
+                        initialValue={val.price}
+                      >
+                        {({ value }) => <p>{value}</p>}
+                      </FieldArrayItem>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </FieldArray>
+            <button type="button" onClick={() => reset()}>
+              Reset
+            </button>
+          </form>
+        )}
+      </Form>
+    );
+  };
+
+  const { getByText } = render(<Comp />);
+
+  expect(getByText("Clean")).toBeInTheDocument();
 
   await user.click(getByText("Reset"));
 

--- a/lib/field/field.spec.tsx
+++ b/lib/field/field.spec.tsx
@@ -1298,3 +1298,37 @@ test("Field should not have duplication when remounts if preserveValue", async (
   rerender(<Comp />);
   expect(getByText("Total fields: 1")).toBeInTheDocument();
 });
+
+test("Field should not be dirty if form is reset", async () => {
+  const { getByPlaceholderText, queryByText, getByText, findByText } = render(
+    <Form onSubmit={(values) => {}}>
+      {({ reset }) => (
+        <div>
+          <Field<string> name="email" initialValue="">
+            {({ value, setValue, isDirty }) => (
+              <div>
+                <input
+                  placeholder="Email"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                />
+                {isDirty && <p>Dirty</p>}
+              </div>
+            )}
+          </Field>
+          <button onClick={() => reset()}>Reset</button>
+        </div>
+      )}
+    </Form>
+  );
+
+  expect(queryByText("Dirty")).not.toBeInTheDocument();
+
+  await user.type(getByPlaceholderText("Email"), "test");
+
+  expect(getByText("Dirty")).toBeInTheDocument();
+
+  await user.click(getByText("Reset"));
+
+  expect(queryByText("Dirty")).not.toBeInTheDocument();
+});

--- a/lib/form/form.tsx
+++ b/lib/form/form.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { ZodError } from "zod";
 import { fillPath, getValidationError, stringToPath, validate } from "../utils";
-import { FieldInstance } from "../field";
+import { FieldInstance, InternalValue } from "../field";
 import { FieldArrayInstance } from "../field-array";
 import { ErrorsMap, FormInstance } from "./types";
 import { FormContext } from "./context";
@@ -260,12 +260,12 @@ function FormComp<T extends Record<string, any> = Record<string, any>>(
           field.setValues({
             __value: value || [],
             __isResetting: true,
-          } as unknown as any[]);
+          } as InternalValue<T> as unknown as T[]);
         } else if (isField(field)) {
           field.setValue({
             __value: value || "",
             __isResetting: true,
-          } as unknown as any);
+          } as InternalValue<T> as unknown as T);
         }
       });
     _setErrors([]);


### PR DESCRIPTION
Previously, using a `Form.reset` would not update `isDirty` properly for any fields. This is because the initial work done by @joaom00 was not caught in this component, as it does not use the same `useFieldLike` logic.

Fixes #107