### PR TITLE
chore: support React 16.x-17.x

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Field, Form } from "houseform";
 import { z } from "zod";
 

--- a/lib/benchmarks/initial-render.bench.tsx
+++ b/lib/benchmarks/initial-render.bench.tsx
@@ -1,5 +1,6 @@
 import { describe, bench } from "vitest";
 
+import React from "react";
 import { Field, Form } from "houseform";
 import { cleanup, findByTestId, render } from "@testing-library/react";
 import { Formik, Field as FormikField } from "formik";

--- a/lib/benchmarks/onblur-detection.bench.tsx
+++ b/lib/benchmarks/onblur-detection.bench.tsx
@@ -1,5 +1,6 @@
 import { describe, bench } from "vitest";
 
+import React from "react";
 import { Field, Form } from "houseform";
 import { z } from "zod";
 import {

--- a/lib/benchmarks/onchange-detection.bench.tsx
+++ b/lib/benchmarks/onchange-detection.bench.tsx
@@ -12,7 +12,7 @@ import { Formik, Field as FormikField } from "formik";
 import { toFormikValidationSchema } from "zod-formik-adapter";
 import { FieldProps } from "formik/dist/Field";
 import { Controller, useForm } from "react-hook-form";
-import { useState } from "react";
+import React, { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorMessage } from "@hookform/error-message";
 

--- a/lib/benchmarks/onmount-detection.bench.tsx
+++ b/lib/benchmarks/onmount-detection.bench.tsx
@@ -12,7 +12,7 @@ import { Formik, Field as FormikField } from "formik";
 import { toFormikValidationSchema } from "zod-formik-adapter";
 import { FieldProps } from "formik/dist/Field";
 import { Controller, useForm } from "react-hook-form";
-import { useState } from "react";
+import React, { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 const arr = Array.from({ length: 1000 }, (_, i) => i);

--- a/lib/benchmarks/onsubmit-detection.bench.tsx
+++ b/lib/benchmarks/onsubmit-detection.bench.tsx
@@ -12,7 +12,7 @@ import { Formik, Field as FormikField } from "formik";
 import { toFormikValidationSchema } from "zod-formik-adapter";
 import { FieldProps } from "formik/dist/Field";
 import { Controller, useForm } from "react-hook-form";
-import { useState } from "react";
+import React, { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ErrorMessage } from "@hookform/error-message";
 

--- a/lib/benchmarks/onsubmit.bench.tsx
+++ b/lib/benchmarks/onsubmit.bench.tsx
@@ -1,7 +1,7 @@
 import { describe, bench } from "vitest";
 
 import { Field, Form } from "houseform";
-import { useState } from "react";
+import React, { useState } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { Formik, Field as FormikField } from "formik";
 import { Controller, useForm } from "react-hook-form";

--- a/lib/benchmarks/unrelated-re-render.bench.tsx
+++ b/lib/benchmarks/unrelated-re-render.bench.tsx
@@ -10,7 +10,7 @@ import {
 import { Formik, FastField as FormikFastField } from "formik";
 import { FieldProps } from "formik/dist/Field";
 import { Controller, useForm } from "react-hook-form";
-import { useState } from "react";
+import React, { useState } from "react";
 
 const arr = Array.from({ length: 1000 }, (_, i) => i);
 

--- a/lib/field-array-item/field-array-item.spec.tsx
+++ b/lib/field-array-item/field-array-item.spec.tsx
@@ -5,7 +5,7 @@ import {
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import { Field, FieldArray, FieldArrayItem, Form } from "houseform";
-import { useState } from "react";
+import React, { useState } from "react";
 import { z } from "zod";
 
 test("Field array item should submit with values in tact", async () => {

--- a/lib/field-array/field-array.tsx
+++ b/lib/field-array/field-array.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   ForwardedRef,
   forwardRef,
   memo,

--- a/lib/field/field.spec.tsx
+++ b/lib/field/field.spec.tsx
@@ -8,7 +8,7 @@ import {
 import { Field, FieldInstance, Form, FormInstance } from "houseform";
 
 import { z } from "zod";
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 test("Field should render children", () => {
   const { getByText } = render(

--- a/lib/form/form.tsx
+++ b/lib/form/form.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   ForwardedRef,
   forwardRef,
   memo,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "paths": {
       "houseform": ["./lib"]
     }


### PR DESCRIPTION
After needing to downgrade a project to React 17 (due to a different library being incompatible with 18) noticed that there were `react-jsx` issues with houseform. 
![image](https://github.com/houseform/houseform/assets/14936212/359ca8ca-55f6-4664-b74b-961ec5f0ca68)

Something feels odd about having to downgrade the `jsx` setting and import `React` in some files, but seemed to do the trick!

Happy to push up the test repo i linked to if ya need!

Closes #111 