### PR TITLE
feat: allow null|undefined for initialValue via explicitInitialValue

### DIFF
--- a/lib/field-array/types.ts
+++ b/lib/field-array/types.ts
@@ -15,6 +15,7 @@ export interface FieldArrayInstanceProps<T = any, F = any>
   resetWithValue?: T[];
   memoChild?: any[];
   preserveValue?: boolean;
+  explicitInitialValue?: boolean;
 }
 
 export interface FieldArrayInstance<T = any, F = any>

--- a/lib/field/field.spec.tsx
+++ b/lib/field/field.spec.tsx
@@ -34,6 +34,62 @@ test("Field should render with initial values", async () => {
   expect(getByText("test@example.com")).toBeInTheDocument();
 });
 
+test("Field should default to empty string initialValue", async () => {
+  const { queryByText } = render(
+    <Form onSubmit={(_) => {}}>
+      {() => (
+        <>
+          <Field<string | null> name={"email"} initialValue={null}>
+            {({ value }) => <p>{value === "" ? "" : "FAIL"}</p>}
+          </Field>
+          <Field<string> name={"email"}>
+            {({ value }) => <p>{value === "" ? "" : "FAIL"}</p>}
+          </Field>
+        </>
+      )}
+    </Form>
+  );
+
+  expect(queryByText("FAIL")).not.toBeInTheDocument();
+});
+
+test("Field should default to empty string for undefined initialValue", async () => {
+  const { queryByText } = render(
+    <Form onSubmit={(_) => {}}>
+      {() => (
+        <Field<string> name={"email"}>
+          {({ value }) => <p>{value === "" ? "PASS" : "FAIL"}</p>}
+        </Field>
+      )}
+    </Form>
+  );
+
+  expect(queryByText("PASS")).toBeInTheDocument();
+});
+
+test("Field should passthrough initialValue if explicitInitialValue is set", async () => {
+  const { queryByText } = render(
+    <Form onSubmit={(_) => {}}>
+      {() => (
+        <>
+          <Field<string> name={"email"} explicitInitialValue={true}>
+            {({ value }) => <p>{value === undefined ? "" : "FAIL"}</p>}
+          </Field>
+          <Field<string | null>
+            name={"email"}
+            explicitInitialValue={true}
+            initialValue={null}
+          >
+            {({ value }) => <p>{value === null ? "" : "FAIL"}</p>}
+          </Field>
+        </>
+      )}
+    </Form>
+  );
+
+  expect(queryByText("FAIL")).not.toBeInTheDocument();
+});
+
 test("Field should allow changing value", async () => {
   const { getByPlaceholderText } = render(
     <Form onSubmit={(_) => {}}>

--- a/lib/field/types.ts
+++ b/lib/field/types.ts
@@ -25,6 +25,7 @@ export interface FieldInstanceProps<T = any, F = any>
   resetWithValue?: T;
   memoChild?: any[];
   preserveValue?: boolean;
+  explicitInitialValue?: boolean;
 }
 
 export interface FieldInstance<T = any, F = any> {

--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -182,11 +182,11 @@ export const useFieldLike = <
     [formContext, props]
   );
 
-  const initVal = (props.initialValue ?? initialValue) as UseFieldLikeProps<
-    T,
-    F,
-    TT
-  >["initialValue"];
+  const initVal = (
+    props.explicitInitialValue
+      ? props.initialValue
+      : props.initialValue ?? initialValue
+  ) as UseFieldLikeProps<T, F, TT>["initialValue"];
 
   const hasRanMountHook = useRef(false);
   const [value, _setValue] = useState<


### PR DESCRIPTION
Before this commit using a null or undefined lead to a initialValue of "" : string. Since people might depend on this,
introduce the explicitInitialValue prop to opt out of this behaviour.