### PR TITLE
fix: setValue should accept null

### DIFF
--- a/lib/field/use-field-like.ts
+++ b/lib/field/use-field-like.ts
@@ -21,6 +21,7 @@ export type InternalValue<T> = {
 export const isInternal = <T>(value: any): value is InternalValue<T> => {
   return (
     !Array.isArray(value) &&
+    value !== null &&
     typeof value === "object" &&
     "__isResetting" in value
   );


### PR DESCRIPTION
setValue(null) throws errors, because typeof null is 'object' and  `"__isResetting" in null` is not allowed.